### PR TITLE
chore: configure lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,8 @@
+version: "2"
+linters:
+  default: all
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck


### PR DESCRIPTION
```
main.go:85:22: response body must be closed (bodyclose)
	res, err := http.Get(fmt.Sprintf("http://localhost:%d/healthz", config.Port))
	                    ^
main.go:120:1: calculated cyclomatic complexity for function handleReport is 11, max is 10 (cyclop)
func handleReport(config Config, metrics Metrics) http.HandlerFunc {
^
config.go:9:2: import 'github.com/spf13/viper' is not allowed from list 'Main' (depguard)
	"github.com/spf13/viper"
	^
main.go:14:2: import 'github.com/prometheus/client_golang/prometheus' is not allowed from list 'Main' (depguard)
	"github.com/prometheus/client_golang/prometheus"
	^
main.go:15:2: import 'github.com/prometheus/client_golang/prometheus/collectors' is not allowed from list 'Main' (depguard)
	"github.com/prometheus/client_golang/prometheus/collectors"
	^
main.go:16:2: import 'github.com/prometheus/client_golang/prometheus/promhttp' is not allowed from list 'Main' (depguard)
	"github.com/prometheus/client_golang/prometheus/promhttp"
	^
main.go:156:7: do not compare errors directly "err == io.ErrUnexpectedEOF", use "errors.Is(err, io.ErrUnexpectedEOF)" instead (err113)
			if err == io.ErrUnexpectedEOF {
			   ^
report.go:32:9: do not define dynamic errors, use wrapped static errors instead: "fmt.Errorf(\"invalid time '%s'\", trimmed)" (err113)
	return fmt.Errorf("invalid time '%s'", trimmed)
	       ^
report.go:67:10: do not define dynamic errors, use wrapped static errors instead: "fmt.Errorf(\"invalid mx-host '%s'\", string(input))" (err113)
		return fmt.Errorf("invalid mx-host '%s'", string(input))
		       ^
main.go:116:13: Error return value of `fmt.Fprint` is not checked (errcheck)
		fmt.Fprint(w, response)
		          ^
main.go:130:21: Error return value of `r.Body.Close` is not checked (errcheck)
		defer r.Body.Close()
		                  ^
main.go:139:25: Error return value of `gzipReader.Close` is not checked (errcheck)
		defer gzipReader.Close()
		                      ^
main.go:149:21: Error return value of `file.Close` is not checked (errcheck)
				defer file.Close()
				                ^
report_test.go:58:13: Error return value of `encoding/json.Marshal` is not checked: unsafe type `github.com/phi-ag/mta-sts-exporter.RFC3339OptionalTimezone` found (errchkjson)
	json, _ := json.Marshal(report)
	           ^
main.go:31:46: prometheus.CounterOpts is missing fields Subsystem, ConstLabels (exhaustruct)
		PolicyRequestsTotal: prometheus.NewCounter(prometheus.CounterOpts{
		                                           ^
main.go:36:46: prometheus.CounterOpts is missing fields Subsystem, ConstLabels (exhaustruct)
		ReportRequestsTotal: prometheus.NewCounter(prometheus.CounterOpts{
		                                           ^
main.go:41:47: prometheus.CounterOpts is missing fields Subsystem, ConstLabels (exhaustruct)
		ReportErrorsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
		                                            ^
main.go:77:35: collectors.ProcessCollectorOpts is missing fields PidFn, Namespace, ReportErrors (exhaustruct)
			collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
			                               ^
main.go:197:17: promhttp.HandlerOpts is missing fields ErrorLog, ErrorHandling, DisableCompression, OfferedCompressions, MaxRequestsInFlight, Timeout, EnableOpenMetrics, EnableOpenMetricsTextCreatedSamples, ProcessStartTime (exhaustruct)
		handlerOpts = promhttp.HandlerOpts{Registry: registry}
		              ^
main.go:199:17: promhttp.HandlerOpts is missing fields ErrorLog, ErrorHandling, Registry, DisableCompression, OfferedCompressions, MaxRequestsInFlight, Timeout, EnableOpenMetrics, EnableOpenMetricsTextCreatedSamples, ProcessStartTime (exhaustruct)
		handlerOpts = promhttp.HandlerOpts{}
		              ^
main_test.go:30:12: main.Config is missing fields Port, Log, Policy, Reports, Metrics (exhaustruct)
	config := Config{}
	          ^
main_test.go:54:12: main.Config is missing fields Port, Log, Policy, Reports, Metrics (exhaustruct)
	config := Config{}
	          ^
main_test.go:82:12: main.Config is missing fields Port, Log, Policy, Metrics (exhaustruct)
	config := Config{
	          ^
main_test.go:83:12: main.Reports is missing fields Enabled, Path, Save (exhaustruct)
		Reports: Reports{
		         ^
main_test.go:117:12: main.Config is missing fields Port, Log, Policy, Metrics (exhaustruct)
	config := Config{
	          ^
main_test.go:118:12: main.Reports is missing fields Enabled, Path, Save (exhaustruct)
		Reports: Reports{
		         ^
main_test.go:152:12: main.Config is missing fields Port, Log, Policy, Metrics (exhaustruct)
	config := Config{
	          ^
main_test.go:153:12: main.Reports is missing fields Enabled, Path, Save (exhaustruct)
		Reports: Reports{
		         ^
main_test.go:197:12: main.Config is missing fields Port, Log, Policy, Reports, Metrics (exhaustruct)
	config := Config{}
	          ^
main_test.go:218:12: main.Config is missing fields Port, Log, Reports, Metrics (exhaustruct)
	config := Config{
	          ^
main_test.go:219:11: main.Policy is missing fields Enabled, Path (exhaustruct)
		Policy: Policy{
		        ^
report.go:108:13: main.Report is missing fields OrganizationName, DateRange, ContactInfo, ReportId, Policies (exhaustruct)
	report := &Report{}
	           ^
report_test.go:50:12: main.Report is missing fields ContactInfo, ReportId, Policies (exhaustruct)
	report := Report{
	          ^
main.go:213:14: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
			log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", config.Metrics.Port), metricsHttp))
			          ^
main.go:227:12: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", config.Port), publicHttp))
	          ^
report.go:114:9: G301: Expect directory permissions to be 0750 or less (gosec)
	err := os.MkdirAll(config.Reports.Save.Path, os.ModePerm)
	       ^
report.go:124:15: G304: Potential file inclusion via variable (gosec)
	file, err := os.Create(target)
	             ^
config.go:77:27: Magic number: 8080, in <argument> detected (mnd)
	viper.SetDefault("Port", 8080)
	                         ^
config.go:86:46: Magic number: 1024, in <argument> detected (mnd)
	viper.SetDefault("Reports.Max.Body", 1*1024*1024)
	                                            ^
config.go:87:46: Magic number: 1024, in <argument> detected (mnd)
	viper.SetDefault("Reports.Max.Json", 5*1024*1024)
	                                            ^
config.go:91:35: Magic number: 8081, in <argument> detected (mnd)
	viper.SetDefault("Metrics.Port", 8081)
	                                 ^
main.go:88:3: return with no blank line before (nlreturn)
		return 1
		^
main.go:90:2: return with no blank line before (nlreturn)
	return 0
	^
main.go:104:2: return with no blank line before (nlreturn)
	return sb.String()
	^
main_test.go:26:1: Function TestReportReturnsMethodNotAllowedForGetRequest missing the call to method parallel (paralleltest)
func TestReportReturnsMethodNotAllowedForGetRequest(t *testing.T) {
^
main_test.go:47:1: Function TestReportReturnsBadRequestForNonGzip missing the call to method parallel (paralleltest)
func TestReportReturnsBadRequestForNonGzip(t *testing.T) {
^
main_test.go:75:1: Function TestReportReturnsRequestEntityTooLargeForBody missing the call to method parallel (paralleltest)
func TestReportReturnsRequestEntityTooLargeForBody(t *testing.T) {
^
main_test.go:110:1: Function TestReportReturnsRequestEntityTooLargeForJson missing the call to method parallel (paralleltest)
func TestReportReturnsRequestEntityTooLargeForJson(t *testing.T) {
^
main_test.go:145:1: Function TestReportReturnsOk missing the call to method parallel (paralleltest)
func TestReportReturnsOk(t *testing.T) {
^
main_test.go:193:1: Function TestPolicyReturnsMethodNotAllowedForPostRequest missing the call to method parallel (paralleltest)
func TestPolicyReturnsMethodNotAllowedForPostRequest(t *testing.T) {
^
main_test.go:214:1: Function TestPolicyReturnsOk missing the call to method parallel (paralleltest)
func TestPolicyReturnsOk(t *testing.T) {
^
report_test.go:43:1: Function TestParseReportTime missing the call to method parallel (paralleltest)
func TestParseReportTime(t *testing.T) {
^
report_test.go:72:1: Function TestParseReportRfcExample missing the call to method parallel (paralleltest)
func TestParseReportRfcExample(t *testing.T) {
^
report_test.go:75:2: Range statement for test TestParseReportRfcExample missing the call to method parallel in test Run (paralleltest)
	for _, example := range examples {
	^
report_test.go:104:1: Function TestParseReportGoogleExample missing the call to method parallel (paralleltest)
func TestParseReportGoogleExample(t *testing.T) {
^
report_test.go:130:1: Function TestParseReportMicrosoftExample missing the call to method parallel (paralleltest)
func TestParseReportMicrosoftExample(t *testing.T) {
^
report_test.go:152:1: Function TestParseReportMicrosoftExampleWithInvalidTime missing the call to method parallel (paralleltest)
func TestParseReportMicrosoftExampleWithInvalidTime(t *testing.T) {
^
main_test.go:20:12: avoid direct access to proto field *family.Name, use family.GetName() instead (protogetter)
		counters[*family.Name] = *family.Metric[0].Counter.Value
		         ^
config.go:1:1: package-comments: should have a package comment (revive)
package main
^
config.go:12:6: exported: exported type Policy should have comment or be unexported (revive)
type Policy struct {
     ^
config.go:21:6: exported: exported type ReportsMax should have comment or be unexported (revive)
type ReportsMax struct {
     ^
config.go:23:2: var-naming: struct field Json should be JSON (revive)
	Json int64
	^
config.go:26:6: exported: exported type ReportsSave should have comment or be unexported (revive)
type ReportsSave struct {
     ^
config.go:31:6: exported: exported type Reports should have comment or be unexported (revive)
type Reports struct {
     ^
config.go:38:6: exported: exported type ConfigMetrics should have comment or be unexported (revive)
type ConfigMetrics struct {
     ^
config.go:49:6: exported: exported type Config should have comment or be unexported (revive)
type Config struct {
     ^
config.go:52:3: var-naming: struct field Json should be JSON (revive)
		Json bool
		^
main.go:19:6: exported: exported type Metrics should have comment or be unexported (revive)
type Metrics struct {
     ^
main.go:204:2: var-naming: var metricsHttp should be metricsHTTP (revive)
	metricsHttp := http.NewServeMux()
	^
main.go:207:2: var-naming: var publicHttp should be publicHTTP (revive)
	publicHttp := http.NewServeMux()
	^
main.go:243:9: superfluous-else: if block ends with call to os.Exit function, so drop this else and outdent its block (revive)
	} else {
		start(config)
	}
report.go:14:6: exported: exported type RFC3339OptionalTimezone should have comment or be unexported (revive)
type RFC3339OptionalTimezone time.Time
     ^
report.go:16:1: exported: exported method RFC3339OptionalTimezone.UnmarshalJSON should have comment or be unexported (revive)
func (t *RFC3339OptionalTimezone) UnmarshalJSON(input []byte) error {
^
report.go:35:1: exported: exported method RFC3339OptionalTimezone.MarshalJSON should have comment or be unexported (revive)
func (t RFC3339OptionalTimezone) MarshalJSON() ([]byte, error) {
^
report.go:39:6: exported: exported type DateRange should have comment or be unexported (revive)
type DateRange struct {
     ^
report.go:44:6: exported: exported type MxHost should have comment or be unexported (revive)
type MxHost []string
     ^
report.go:46:1: exported: comment on exported method MxHost.UnmarshalJSON should be of the form "UnmarshalJSON ..." (revive)
// NOTE: see https://www.rfc-editor.org/errata/eid6241
^
report.go:71:6: exported: exported type ReportPolicy should have comment or be unexported (revive)
type ReportPolicy struct {
     ^
report.go:78:6: exported: exported type Summary should have comment or be unexported (revive)
type Summary struct {
     ^
report.go:83:6: exported: exported type FailureDetail should have comment or be unexported (revive)
type FailureDetail struct {
     ^
report.go:85:2: var-naming: struct field SendingMtaIp should be SendingMtaIP (revive)
	SendingMtaIp          string `json:"sending-mta-ip"`
	^
report.go:86:2: var-naming: struct field ReceivingIp should be ReceivingIP (revive)
	ReceivingIp           string `json:"receiving-ip"`
	^
report.go:93:6: exported: exported type PolicyItem should have comment or be unexported (revive)
type PolicyItem struct {
     ^
report.go:99:6: exported: exported type Report should have comment or be unexported (revive)
type Report struct {
     ^
report.go:103:2: var-naming: struct field ReportId should be ReportID (revive)
	ReportId         string       `json:"report-id"`
	^
report.go:40:40: json(camel): got 'start-datetime' want 'startDatetime' (tagliatelle)
	StartDatetime RFC3339OptionalTimezone `json:"start-datetime"`
	                                      ^
report.go:41:40: json(camel): got 'end-datetime' want 'endDatetime' (tagliatelle)
	EndDatetime   RFC3339OptionalTimezone `json:"end-datetime"`
	                                      ^
report.go:72:24: json(camel): got 'policy-type' want 'policyType' (tagliatelle)
	PolicyType   string   `json:"policy-type"`
	                      ^
report.go:73:24: json(camel): got 'policy-string' want 'policyString' (tagliatelle)
	PolicyString []string `json:"policy-string"`
	                      ^
report.go:74:24: json(camel): got 'policy-domain' want 'policyDomain' (tagliatelle)
	PolicyDomain string   `json:"policy-domain"`
	                      ^
report.go:75:24: json(camel): got 'mx-host' want 'mxHost' (tagliatelle)
	MxHost       MxHost   `json:"mx-host"`
	                      ^
report.go:79:36: json(camel): got 'total-successful-session-count' want 'totalSuccessfulSessionCount' (tagliatelle)
	TotalSuccessfulSessionCount int64 `json:"total-successful-session-count"`
	                                  ^
report.go:80:36: json(camel): got 'total-failure-session-count' want 'totalFailureSessionCount' (tagliatelle)
	TotalFailureSessionCount    int64 `json:"total-failure-session-count"`
	                                  ^
report.go:84:31: json(camel): got 'result-type' want 'resultType' (tagliatelle)
	ResultType            string `json:"result-type"`
	                             ^
report.go:87:31: json(camel): got 'receiving-mx-hostname' want 'receivingMxHostname' (tagliatelle)
	ReceivingMxHostname   string `json:"receiving-mx-hostname"`
	                             ^
report.go:88:31: json(camel): got 'failed-session-count' want 'failedSessionCount' (tagliatelle)
	FailedSessionCount    int64  `json:"failed-session-count"`
	                             ^
report.go:89:31: json(camel): got 'failure-reason-code' want 'failureReasonCode' (tagliatelle)
	FailureReasonCode     string `json:"failure-reason-code"`
	                             ^
report.go:90:31: json(camel): got 'additional-information' want 'additionalInformation' (tagliatelle)
	AdditionalInformation string `json:"additional-information"`
	                             ^
report.go:96:33: json(camel): got 'failure-details' want 'failureDetails' (tagliatelle)
	FailureDetails []FailureDetail `json:"failure-details"`
	                               ^
report.go:100:32: json(camel): got 'organization-name' want 'organizationName' (tagliatelle)
	OrganizationName string       `json:"organization-name"`
	                              ^
report.go:101:32: json(camel): got 'date-range' want 'dateRange' (tagliatelle)
	DateRange        DateRange    `json:"date-range"`
	                              ^
report.go:102:32: json(camel): got 'contact-info' want 'contactInfo' (tagliatelle)
	ContactInfo      string       `json:"contact-info"`
	                              ^
main.go:94:6: variable name 'sb' is too short for the scope of its usage (varnamelen)
	var sb strings.Builder
	    ^
main.go:110:14: parameter name 'w' is too short for the scope of its usage (varnamelen)
	return func(w http.ResponseWriter, r *http.Request) {
	            ^
main.go:121:37: parameter name 'r' is too short for the scope of its usage (varnamelen)
	return func(w http.ResponseWriter, r *http.Request) {
	                                   ^
report.go:36:9: error returned from external package is unwrapped: sig: func encoding/json.Marshal(v any) ([]byte, error) (wrapcheck)
	return json.Marshal(time.Time(t))
	       ^
report.go:61:11: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error (wrapcheck)
			return err
			       ^
main.go:115:3: expressions should not be cuddled with blocks (wsl)
		metrics.PolicyRequestsTotal.Inc()
		^
main.go:150:5: assignments should only be cuddled with other assignments (wsl)
				jsonReader = saveReader
				^
main_test.go:14:2: only one cuddle assignment allowed before if statement (wsl)
	if err != nil {
	^
main_test.go:35:2: only one cuddle assignment allowed before defer statement (wsl)
	defer res.Body.Close()
	^
main_test.go:59:2: only one cuddle assignment allowed before defer statement (wsl)
	defer res.Body.Close()
	^
main_test.go:94:2: only one cuddle assignment allowed before defer statement (wsl)
	defer res.Body.Close()
	^
report.go:27:2: only one cuddle assignment allowed before if statement (wsl)
	if err == nil {
	^
report.go:60:3: only one cuddle assignment allowed before if statement (wsl)
		if err != nil {
		^
report.go:63:3: assignments should only be cuddled with other assignments (wsl)
		*l = MxHost(tmp)
		^
116 issues:
* bodyclose: 1
* cyclop: 1
* depguard: 4
* err113: 3
* errcheck: 4
* errchkjson: 1
* exhaustruct: 19
* gosec: 4
* mnd: 4
* nlreturn: 3
* paralleltest: 13
* protogetter: 1
* revive: 27
* tagliatelle: 17
* varnamelen: 3
* wrapcheck: 2
* wsl: 9
```